### PR TITLE
feat: group nar scripts by package

### DIFF
--- a/packages/nar-demo/package.json
+++ b/packages/nar-demo/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@demo/nar-demo",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "echo child-package-dev",
+    "build": "echo child-package-build",
+    "lint": "echo child-package-lint"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
-packages: []
+packages:
+  - packages/*
 
 catalogs:
   dev:

--- a/src/nar/cli.ts
+++ b/src/nar/cli.ts
@@ -8,8 +8,14 @@ import { detectProvider } from '../detect.ts'
 import { commandOverviewText } from '../help.ts'
 import { selectSearchPrompt } from '../prompts/select-search.ts'
 import { providers } from '../providers/index.ts'
-import { buildScriptOptions, collectScripts, type ScriptEntry } from './core.ts'
-import type { SearchOption } from '../prompts/search.ts'
+import {
+  buildScriptOptions,
+  collectScripts,
+  getScriptGroupOrder,
+  isScriptEntry,
+  type ScriptEntry,
+  type ScriptOptionValue,
+} from './core.ts'
 
 function printHelp(): void {
   console.log(
@@ -78,7 +84,8 @@ async function run() {
   }
 
   const isMonorepo = packages.length > 1
-  const allOptions = buildScriptOptions(scripts, isMonorepo)
+  const groupOrder = getScriptGroupOrder(scripts)
+  const allOptions = buildScriptOptions(scripts, isMonorepo, groupOrder)
 
   /** Tiebreaker: root scripts rank higher than workspace scripts */
   const byRootFirst = (
@@ -94,17 +101,16 @@ async function run() {
     tiebreakers: [byRootFirst, byLengthAsc],
   })
 
-  const optionMap = new Map(allOptions.map((opt) => [opt.value, opt]))
-
-  const selected = await selectSearchPrompt<ScriptEntry>({
+  const selected = await selectSearchPrompt<ScriptOptionValue>({
     message: 'Run a script',
     options() {
       const input = (this.userInput ?? '').trim()
       if (!input) return allOptions
-      const results = fzf.find(input)
-      return results
-        .map((r) => optionMap.get(r.item))
-        .filter((o): o is SearchOption<ScriptEntry> => o != null)
+      return buildScriptOptions(
+        fzf.find(input).map((result) => result.item),
+        isMonorepo,
+        groupOrder,
+      )
     },
     filter: () => true,
   })
@@ -114,7 +120,12 @@ async function run() {
     process.exit(0)
   }
 
-  const entry = selected as ScriptEntry
+  if (!isScriptEntry(selected)) {
+    p.log.error('Please choose a runnable script.')
+    process.exit(1)
+  }
+
+  const entry: ScriptEntry = selected
 
   try {
     await provider.runScript({

--- a/src/nar/core.ts
+++ b/src/nar/core.ts
@@ -11,6 +11,42 @@ export interface ScriptEntry {
   isRoot: boolean
 }
 
+export interface ScriptGroupMarker {
+  kind: 'group'
+  id: string
+  label: string
+}
+
+export type ScriptOptionValue = ScriptEntry | ScriptGroupMarker
+
+const ROOT_GROUP_ID = '__root__'
+
+function getGroupId(entry: ScriptEntry): string {
+  return entry.isRoot ? ROOT_GROUP_ID : entry.packageName
+}
+
+function getGroupLabel(entry: ScriptEntry): string {
+  return entry.isRoot ? 'Root scripts' : entry.packageName
+}
+
+export function getScriptGroupOrder(scripts: ScriptEntry[]): string[] {
+  const seen = new Set<string>()
+  const order: string[] = []
+
+  for (const entry of scripts) {
+    const groupId = getGroupId(entry)
+    if (seen.has(groupId)) continue
+    seen.add(groupId)
+    order.push(groupId)
+  }
+
+  return order
+}
+
+export function isScriptEntry(value: ScriptOptionValue): value is ScriptEntry {
+  return 'scriptName' in value
+}
+
 /**
  * Collect all runnable scripts from workspace packages.
  * The first package is treated as root.
@@ -35,13 +71,48 @@ export function collectScripts(packages: RepoPackageItem[]): ScriptEntry[] {
 export function buildScriptOptions(
   scripts: ScriptEntry[],
   isMonorepo: boolean,
-): SearchOption<ScriptEntry>[] {
-  return scripts.map((entry) => ({
-    value: entry,
-    label:
-      isMonorepo && !entry.isRoot
-        ? `${c.magenta(entry.packageName)} ${c.dim('>')} ${entry.scriptName}`
-        : entry.scriptName,
-    hint: entry.command,
-  }))
+  groupOrder: string[] = getScriptGroupOrder(scripts),
+): SearchOption<ScriptOptionValue>[] {
+  if (!isMonorepo) {
+    return scripts.map((entry) => ({
+      value: entry,
+      label: entry.scriptName,
+      hint: entry.command,
+    }))
+  }
+
+  const groups = new Map<string, SearchOption<ScriptOptionValue>[]>()
+  const groupLabels = new Map<string, string>()
+
+  for (const entry of scripts) {
+    const groupId = getGroupId(entry)
+    if (!groups.has(groupId)) groups.set(groupId, [])
+    groupLabels.set(groupId, getGroupLabel(entry))
+    groups.get(groupId)!.push({
+      value: entry,
+      label: entry.scriptName,
+      hint: entry.command,
+    })
+  }
+
+  const orderedGroupIds = [
+    ...groupOrder.filter((groupId) => groups.has(groupId)),
+    ...[...groups.keys()].filter((groupId) => !groupOrder.includes(groupId)),
+  ]
+
+  return orderedGroupIds.flatMap((groupId) => {
+    const label = groupLabels.get(groupId) ?? groupId
+    return [
+      {
+        value: {
+          kind: 'group',
+          id: groupId,
+          label,
+        },
+        label: c.bold(label),
+        disabled: true,
+      },
+      ...groups.get(groupId)!,
+    ]
+  })
 }

--- a/src/prompts/select-search.ts
+++ b/src/prompts/select-search.ts
@@ -34,6 +34,10 @@ export async function selectSearchPrompt<T = string>(
     render(this: AutocompletePrompt<SearchOption<T>>) {
       const input = this.userInput
       const allOptions = this.options
+      const totalSelectableOptions = allOptions.filter((o) => !o.disabled).length
+      const filteredSelectableOptions = this.filteredOptions.filter(
+        (o) => !o.disabled,
+      ).length
       const color = this.state === 'error' ? 'yellow' : 'cyan'
       const bar = styleText(color, S_BAR)
 
@@ -47,11 +51,11 @@ export async function selectSearchPrompt<T = string>(
           : cursor
 
       const matchInfo =
-        this.filteredOptions.length === allOptions.length
+        filteredSelectableOptions === totalSelectableOptions
           ? ''
           : styleText(
               'dim',
-              ` (${this.filteredOptions.length} match${this.filteredOptions.length === 1 ? '' : 'es'})`,
+              ` (${filteredSelectableOptions} match${filteredSelectableOptions === 1 ? '' : 'es'})`,
             )
 
       switch (this.state) {
@@ -71,6 +75,9 @@ export async function selectSearchPrompt<T = string>(
 
           const styleOption = (option: SearchOption<T>, active: boolean) => {
             const label = option.label ?? String(option.value ?? '')
+            if (option.disabled) {
+              return styleText(['bold', 'dim'], label)
+            }
             const hint =
               option.hint && active ? styleText('dim', ` (${option.hint})`) : ''
             const radio = active

--- a/tests/nar/core.test.ts
+++ b/tests/nar/core.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildScriptOptions, collectScripts } from '../../src/nar/core.ts'
+import {
+  buildScriptOptions,
+  collectScripts,
+  getScriptGroupOrder,
+} from '../../src/nar/core.ts'
 import type { RepoPackageItem } from '../../src/type.ts'
 
 // eslint-disable-next-line no-control-regex
@@ -129,13 +133,17 @@ describe('buildScriptOptions', () => {
   it('omits package name for root scripts in monorepo', () => {
     const options = buildScriptOptions(entries, true)
 
-    expect(strip(options[0].label)).toBe('dev')
+    expect(strip(options[0].label)).toBe('Root scripts')
+    expect(options[0].disabled).toBe(true)
+    expect(strip(options[1].label)).toBe('dev')
   })
 
-  it('prefixes package name for non-root scripts in monorepo', () => {
+  it('creates package group headers for non-root scripts in monorepo', () => {
     const options = buildScriptOptions(entries, true)
 
-    expect(strip(options[1].label)).toBe('@scope/pkg-a > build')
+    expect(strip(options[2].label)).toBe('@scope/pkg-a')
+    expect(options[2].disabled).toBe(true)
+    expect(strip(options[3].label)).toBe('build')
   })
 
   it('sets command as hint', () => {
@@ -155,5 +163,32 @@ describe('buildScriptOptions', () => {
   it('returns empty array for empty input', () => {
     expect(buildScriptOptions([], false)).toEqual([])
     expect(buildScriptOptions([], true)).toEqual([])
+  })
+
+  it('keeps group order as root first, then workspace packages in order', () => {
+    const packageBEntry = {
+      scriptName: 'lint',
+      command: 'eslint .',
+      packageName: '@scope/pkg-b',
+      cwd: '/workspace/pkg-b',
+      isRoot: false,
+    }
+    const fullEntries = [rootEntry, workspaceEntry, packageBEntry]
+    const filteredEntries = [packageBEntry, rootEntry, workspaceEntry]
+
+    const options = buildScriptOptions(
+      filteredEntries,
+      true,
+      getScriptGroupOrder(fullEntries),
+    )
+
+    expect(options.map((option) => strip(option.label))).toEqual([
+      'Root scripts',
+      'dev',
+      '@scope/pkg-a',
+      'build',
+      '@scope/pkg-b',
+      'lint',
+    ])
   })
 })


### PR DESCRIPTION

![Kapture 2026-03-25 at 04 05 05](https://github.com/user-attachments/assets/96829f26-b289-43e7-8686-55a0464a359f)


## Summary
- add grouped sections to the nar interactive script selector for monorepos
- keep root scripts first and show workspace package scripts in package order using disabled group headers
- add tests and a demo workspace package for manual verification

## Testing
- pnpm vitest run tests/nar/core.test.ts
- pnpm typecheck
